### PR TITLE
feat: create templates to allow replacing the generic Django view to …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,7 @@ Quick start
         'app.ClassName',    # excluding from logging only for this model
     )
 
+4. To override Django's default view to show the history of a log, use LogModelAdmin instead of ModelAdmin::
+
+    class ExampleAdmin(LogModelAdmin):
+        pass

--- a/model_log/admin.py
+++ b/model_log/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+
+from model_log.mixins import ModelAdminMixin
 from .models import Log
 
 
@@ -10,6 +12,19 @@ class LogAdmin(admin.ModelAdmin):
     readonly_fields = ('object_id', 'model', 'action', 'data', 'date_created', 'user')
 
     search_fields = ('id', 'object_id', 'model', 'action', 'date_created', 'user')
+
+    change_form_template = "change_form.html"
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
+class LogModelAdmin(ModelAdminMixin, admin.ModelAdmin):
+    """ Use this class instead of ModelAdmin. """
+    pass
 
 
 admin.site.register(Log, LogAdmin)

--- a/model_log/mixins.py
+++ b/model_log/mixins.py
@@ -1,0 +1,46 @@
+from django.contrib.admin.utils import unquote
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
+from django.utils.text import capfirst
+from django.utils.translation import gettext as _
+from model_log.models import Log
+
+
+class ModelAdminMixin:
+    object_history_template = "object_history.html"
+
+    def history_view(self, request, object_id, extra_context=None):
+        "The 'history' admin view for this model."
+        from django.contrib.admin.models import LogEntry
+        # First check if the user can see this history.
+        model = self.model
+        obj = self.get_object(request, unquote(object_id))
+        if obj is None:
+            return self._get_obj_does_not_exist_redirect(request, model._meta, object_id)
+
+        if not self.has_view_or_change_permission(request, obj):
+            raise PermissionDenied
+
+        # Then get the history for this object.
+        opts = model._meta
+        app_label = opts.app_label
+        log_data = Log.objects.filter(model=obj.__class__.__name__.lower())
+
+        context = {
+            **self.admin_site.each_context(request),
+            'title': _('Change history: %s') % obj,
+            'action_list': log_data,
+            'module_name': str(capfirst(opts.verbose_name_plural)),
+            'object': obj,
+            'opts': opts,
+            'preserved_filters': self.get_preserved_filters(request),
+            **(extra_context or {}),
+        }
+
+        request.current_app = self.admin_site.name
+
+        return TemplateResponse(request, self.object_history_template or [
+            "admin/%s/%s/object_history.html" % (app_label, opts.model_name),
+            "admin/%s/object_history.html" % app_label,
+            "admin/object_history.html"
+        ], context)

--- a/model_log/templates/change_form.html
+++ b/model_log/templates/change_form.html
@@ -1,0 +1,81 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block extrahead %}{{ block.super }}
+<script src="{% url 'admin:jsi18n' %}"></script>
+{{ media }}
+{% endblock %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% block coltype %}colM{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}<div id="content-main">
+{% block object-tools %}
+{% if change %}{% if not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+        {# {% change_form_object_tools %} #}
+    {% endblock %}
+  </ul>
+{% endif %}{% endif %}
+{% endblock %}
+<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
+<div>
+{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+{% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
+{% if errors %}
+    <p class="errornote">
+    {% if errors|length == 1 %}{% translate "Please correct the error below." %}{% else %}{% translate "Please correct the errors below." %}{% endif %}
+    </p>
+    {{ adminform.form.non_field_errors }}
+{% endif %}
+
+{% block field_sets %}
+{% for fieldset in adminform %}
+  {% include "admin/includes/fieldset.html" %}
+{% endfor %}
+{% endblock %}
+
+{% block after_field_sets %}{% endblock %}
+
+{% block inline_field_sets %}
+{% for inline_admin_formset in inline_admin_formsets %}
+    {% include inline_admin_formset.opts.template %}
+{% endfor %}
+{% endblock %}
+
+{% block after_related_objects %}{% endblock %}
+
+{% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+
+{% block admin_change_form_document_ready %}
+    <script id="django-admin-form-add-constants"
+            src="{% static 'admin/js/change_form.js' %}"
+            {% if adminform and add %}
+                data-model-name="{{ opts.model_name }}"
+            {% endif %}
+            async>
+    </script>
+{% endblock %}
+
+{# JavaScript for prepopulated fields #}
+{% prepopulated_fields_js %}
+
+</div>
+</form></div>
+{% endblock %}

--- a/model_log/templates/object_history.html
+++ b/model_log/templates/object_history.html
@@ -1,0 +1,46 @@
+{% extends "admin/object_history.html" %}
+{% load i18n %}
+{% load admin_urls %}
+
+
+{% block content %}
+  <div id="content-main">
+    <div class="module">
+      {% if action_list %}
+        <table id="change-history">
+        <thead>
+        <tr>
+            <th scope="col">ID</th>
+            <th scope="col">Model ID</th>
+            <th scope="col">Model</th>
+            <th scope="col">Data</th>
+            <th scope="col">Date created</th>
+            <th scope="col">Action</th>
+            <th scope="col">User</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for action in action_list %}
+        <tr>
+            <td>
+                <a href="/admin/model_log/log/{{ action.id }}/change/">
+                    {{ action.id }}
+                </a>
+            </td>
+
+            <td>{{ action.object_id }}</td>
+            <td>{{ action.model }}</td>
+            <td>{{ action.data }}</td>
+            <td>{{ action.date_created }}</td>
+            <td>{{ action.action.verbose_name }}</td>
+            <td>{{ action.user }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+      {% else %}
+        <p>{% trans "This object doesn't have a change history." %}</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
…see the history of each record.

- I disabled the permission to create and modify a story.
- Create the template to display the list of stories for a record.
- I took the change_form template to not show the History button in the Log view, since it is not necessary to see the history of the stories model.

